### PR TITLE
Adjust source to compile with spark 2.0

### DIFF
--- a/chronix-spark-ts-rdd/build.gradle
+++ b/chronix-spark-ts-rdd/build.gradle
@@ -11,10 +11,10 @@ dependencies {
 
     //Spark dependencies. compileOnly & testCompile because they
     //are provided by Zeppelin et al.
-    compileOnly 'org.apache.spark:spark-core_2.10:1.6.1'
-    compileOnly 'org.apache.spark:spark-sql_2.10:1.6.1'
-    testCompile 'org.apache.spark:spark-core_2.10:1.6.1'
-    testCompile 'org.apache.spark:spark-sql_2.10:1.6.1'
+    compileOnly 'org.apache.spark:spark-core_2.11:2.0.0'
+    compileOnly 'org.apache.spark:spark-sql_2.11:2.0.0'
+    testCompile 'org.apache.spark:spark-core_2.11:2.0.0'
+    testCompile 'org.apache.spark:spark-sql_2.11:2.0.0'
     //Kryo for test data storage (with included shaded asm - just to be sure)
     testCompile 'com.esotericsoftware:kryo-shaded:3.0.3'
     testCompile 'org.yaml:snakeyaml:1.17'

--- a/chronix-spark-ts-rdd/src/main/java/de/qaware/chronix/spark/api/java/ChronixRDD.java
+++ b/chronix-spark-ts-rdd/src/main/java/de/qaware/chronix/spark/api/java/ChronixRDD.java
@@ -25,7 +25,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.DoubleFunction;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SQLContext;
@@ -193,7 +193,7 @@ public class ChronixRDD extends JavaRDD<MetricTimeSeries> {
      * @return a RDD with all observation values
      */
     public JavaDoubleRDD getValuesAsRdd() {
-        return this.flatMapToDouble(mts -> Arrays.asList(ArrayUtils.toObject(mts.getValuesAsArray())));
+        return this.flatMapToDouble(mts -> Arrays.asList(ArrayUtils.toObject(mts.getValuesAsArray())).iterator());
     }
 
     /**
@@ -232,7 +232,7 @@ public class ChronixRDD extends JavaRDD<MetricTimeSeries> {
                     point.getTimestamp(),
                     point.getValue()
             );
-        })::iterator);
+        }).iterator());
     }
 
     /**
@@ -248,7 +248,7 @@ public class ChronixRDD extends JavaRDD<MetricTimeSeries> {
      * @param sqlContext an open SQLContext
      * @return a DataFrame containing the ChronixRDD data
      */
-    public DataFrame toDataFrame(SQLContext sqlContext) {
+    public Dataset toDataFrame(SQLContext sqlContext) {
         return sqlContext.createDataFrame(
                 this.toObservations(),
                 MetricObservation.class

--- a/chronix-spark-ts-rdd/src/main/java/de/qaware/chronix/spark/api/java/ChronixSparkContext.java
+++ b/chronix-spark-ts-rdd/src/main/java/de/qaware/chronix/spark/api/java/ChronixSparkContext.java
@@ -96,7 +96,7 @@ public class ChronixSparkContext implements Serializable {
         // parallelize the requests to the shards
         JavaRDD<MetricTimeSeries> docs = jsc.parallelize(shards, shards.size()).flatMap(
                 (FlatMapFunction<String, MetricTimeSeries>) shardUrl -> chronixStorage.streamFromSingleNode(
-                        zkHost, collection, shardUrl, query, new MetricTimeSeriesConverter())::iterator);
+                        zkHost, collection, shardUrl, query, new MetricTimeSeriesConverter()).iterator());
         return new ChronixRDD(docs);
     }
 

--- a/chronix-spark-ts-rdd/src/test/groovy/de/qaware/chronix/spark/api/java/TestChronixRDD.groovy
+++ b/chronix-spark-ts-rdd/src/test/groovy/de/qaware/chronix/spark/api/java/TestChronixRDD.groovy
@@ -20,7 +20,6 @@ import de.qaware.chronix.storage.solr.timeseries.metric.MetricDimension
 import de.qaware.chronix.storage.solr.timeseries.metric.MetricObservation
 import de.qaware.chronix.storage.solr.timeseries.metric.MetricTimeSeries
 import org.apache.spark.api.java.JavaDoubleRDD
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.SQLContext
 import spock.lang.Shared
@@ -118,7 +117,7 @@ class TestChronixRDD extends Specification {
 
     def "test data frame"() {
         when:
-        DataFrame df = rdd.toDataFrame(sqlContext);
+        Dataset df = rdd.toDataFrame(sqlContext);
         then:
         //Assert that all columns are available
         List<String> columns = Arrays.asList(df.columns());
@@ -131,7 +130,7 @@ class TestChronixRDD extends Specification {
         df.show()
         assertTrue(df.count() > 0);
 
-        DataFrame dfRes = df.select("value", "process").where("process=\"jenkins-jolokia\"")
+        Dataset dfRes = df.select("value", "process").where("process=\"jenkins-jolokia\"")
         dfRes.show()
         assertTrue(dfRes.count() > 0)
     }


### PR DESCRIPTION
Still using some deprecated operations.
